### PR TITLE
Cabal-3.8 has Distribution.Simple.PackageDescription

### DIFF
--- a/Distribution/PackageDescription/TH.hs
+++ b/Distribution/PackageDescription/TH.hs
@@ -47,7 +47,11 @@ import Language.Haskell.TH (Q, Exp, stringE, runIO)
 -- which was introduced in Cabal-2.0.0.2
 -- readPackageDescription was removed in Cabal-2.2.0.0.
 #if MIN_VERSION_Cabal(3,8,1)
+#if MIN_VERSION_Cabal(3,8,0)
 import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+#else
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+#endif
 readPkgDesc = readGenericPackageDescription
 #elif MIN_VERSION_Cabal(2,2,0)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)


### PR DESCRIPTION
fixes failure with ghc-9.4:

Distribution/PackageDescription/TH.hs:45:48: error:
    Module
    ‘Distribution.PackageDescription.Parsec’
    does not export
    ‘readGenericPackageDescription’
   |
45 | import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^